### PR TITLE
Fix for domain model inconsistent rendering

### DIFF
--- a/grails-app/views/inertia/json.gson
+++ b/grails-app/views/inertia/json.gson
@@ -4,7 +4,7 @@ import groovy.transform.Field
 @Field InertiaPage inertiaPage
 json {
     component inertiaPage.component
-    props inertiaPage.props
+    props g.render(inertiaPage.props)
     url inertiaPage.url
     version inertiaPage.version
 }


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/matrei/grails-inertia-plugin/issues/81), rendering props will use default `JsonConverters` for any HTML response, however when making a standard JSON request the response is rendered directly through any user provided `.gson` templates.  This leads to a duplication of logic (as well as a Stack Overflow issue when `JsonConverters` are used for GORM objects).  To prevent this, we can force both instances of HTML and JSON requests to render directly using `.gson` files.